### PR TITLE
Fix payment link charging full invoice total instead of balance due

### DIFF
--- a/src/Merchello.Core/Payments/Services/PaymentLinkService.cs
+++ b/src/Merchello.Core/Payments/Services/PaymentLinkService.cs
@@ -4,6 +4,7 @@ using Merchello.Core.Payments.Models;
 using Merchello.Core.Payments.Providers;
 using Merchello.Core.Payments.Providers.Interfaces;
 using Merchello.Core.Payments.Services.Interfaces;
+using Merchello.Core.Payments.Services.Parameters;
 using Merchello.Core.Shared.Extensions;
 using Merchello.Core.Shared.Models;
 using Microsoft.EntityFrameworkCore;
@@ -66,11 +67,24 @@ public class PaymentLinkService(
             return crudResult;
         }
 
-        // Check if invoice is already paid
-        var paymentStatus = await paymentService.GetInvoicePaymentStatusAsync(invoiceId, cancellationToken);
-        if (paymentStatus == InvoicePaymentStatus.Paid)
+        // Calculate balance due using the single source of truth
+        var payments = await paymentService.GetPaymentsForInvoiceAsync(invoiceId, cancellationToken);
+        var paymentDetails = paymentService.CalculatePaymentStatus(new CalculatePaymentStatusParameters
+        {
+            Payments = payments,
+            InvoiceTotal = invoice.Total,
+            CurrencyCode = invoice.CurrencyCode
+        });
+
+        if (paymentDetails.Status == InvoicePaymentStatus.Paid)
         {
             crudResult.AddErrorMessage("Cannot create payment link for an already paid invoice.");
+            return crudResult;
+        }
+
+        if (paymentDetails.BalanceDue <= 0m)
+        {
+            crudResult.AddErrorMessage("No balance due on this invoice.");
             return crudResult;
         }
 
@@ -100,11 +114,11 @@ public class PaymentLinkService(
         var request = new PaymentLinkRequest
         {
             InvoiceId = invoiceId,
-            Amount = invoice.Total,
+            Amount = paymentDetails.BalanceDue,
             Currency = invoice.CurrencyCode,
             CustomerEmail = invoice.BillingAddress.Email,
             CustomerName = invoice.BillingAddress.Name,
-            Description = $"Invoice {invoice.InvoiceNumber}",
+            Description = $"Invoice {invoice.InvoiceNumber} - Balance due",
             Metadata = new Dictionary<string, string>
             {
                 ["invoiceNumber"] = invoice.InvoiceNumber,

--- a/src/Merchello.Tests/Payments/Services/PaymentLinkServiceTests.cs
+++ b/src/Merchello.Tests/Payments/Services/PaymentLinkServiceTests.cs
@@ -224,6 +224,62 @@ public class PaymentLinkServiceTests : IClassFixture<ServiceTestFixture>
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task CreatePaymentLinkAsync_UsesBalanceDue_WhenInvoicePartiallyPaid()
+    {
+        // Arrange - create invoice for 250.50 and pay 100
+        var dataBuilder = _fixture.CreateDataBuilder();
+        var invoice = dataBuilder.CreateInvoice(total: 250.50m);
+        await dataBuilder.SaveChangesAsync();
+        _fixture.DbContext.ChangeTracker.Clear();
+
+        await _paymentService.RecordPaymentAsync(new RecordPaymentParameters
+        {
+            InvoiceId = invoice.Id,
+            ProviderAlias = "manual",
+            TransactionId = $"txn-{Guid.NewGuid()}",
+            Amount = 100m
+        });
+        _fixture.DbContext.ChangeTracker.Clear();
+
+        // Setup provider mock
+        var mockProvider = new Mock<IPaymentProvider>();
+        mockProvider.Setup(p => p.Metadata).Returns(new PaymentProviderMetadata
+        {
+            Alias = "stripe",
+            DisplayName = "Stripe",
+            SupportsPaymentLinks = true,
+            IconHtml = "<svg>stripe</svg>"
+        });
+        mockProvider
+            .Setup(p => p.CreatePaymentLinkAsync(It.IsAny<PaymentLinkRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaymentLinkResult
+            {
+                Success = true,
+                PaymentUrl = "https://pay.stripe.com/link_partial",
+                ProviderLinkId = "link_partial"
+            });
+
+        var setting = new PaymentProviderSetting { ProviderAlias = "stripe", DisplayName = "Stripe", IsEnabled = true };
+        var registered = new RegisteredPaymentProvider(mockProvider.Object, setting);
+        var pmMock = new Mock<IPaymentProviderManager>();
+        pmMock.Setup(m => m.GetProviderAsync("stripe", true, It.IsAny<CancellationToken>()))
+              .ReturnsAsync(registered);
+
+        var service = CreateService(pmMock);
+
+        // Act
+        var result = await service.CreatePaymentLinkAsync(invoice.Id, "stripe", "admin");
+
+        // Assert - should charge 150.50 (balance due), NOT 250.50 (full total)
+        result.Success.ShouldBeTrue();
+        mockProvider.Verify(p => p.CreatePaymentLinkAsync(
+            It.Is<PaymentLinkRequest>(r =>
+                r.InvoiceId == invoice.Id &&
+                r.Amount == 150.50m),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     #endregion
 
     #region DeactivatePaymentLinkAsync


### PR DESCRIPTION
Payment links were created using invoice.Total, causing customers to be charged the full order value even when partial payments already existed. Now uses PaymentService.CalculatePaymentStatus() to determine the actual balance due before creating the link.